### PR TITLE
init, live-init and tsplash to look for initrd_release

### DIFF
--- a/initrd/bin/tsplash
+++ b/initrd/bin/tsplash
@@ -365,7 +365,9 @@ verbose_progress() {
 # is cached.
 #------------------------------------------------------------------------------
 get_welcome_msg() {
-    read_distro_release /etc/initrd-release
+    local initrd_release=/etc/initrd_release
+    [ -r $initrd_release ] || initrd_release=/etc/initrd-release
+    read_distro_release $initrd_release
     : ${DISTRO_BUG_REPORT_URL:=$BUG_REPORT_URL}
     : ${DISTRO_NAME:=antiX}
     : ${DISTRO_PRETTY_NAME:=antiX-17 (generic)}
@@ -890,8 +892,8 @@ prog_dd() {
 
     sync ; sync
 
-    echo $dirty_bytes >> /proc/sys/vm/dirty_bytes
-    echo $dirty_ratio >> /proc/sys/vm/dirty_ratio
+    [ ${dirty_bytes:-0} -gt 0 ] 2>/dev/null && echo $dirty_bytes > /proc/sys/vm/dirty_bytes
+    [ ${dirty_ratio:-0} -gt 0 ] 2>/dev/null && echo $dirty_ratio > /proc/sys/vm/dirty_ratio
 
     log_it 'text_progress done'
 
@@ -950,8 +952,8 @@ prog_copy() {
 
     sync ; sync
 
-    echo $dirty_bytes >> /proc/sys/vm/dirty_bytes
-    echo $dirty_ratio >> /proc/sys/vm/dirty_ratio
+    [ ${dirty_bytes:-0} -gt 0 ] 2>/dev/null && echo $dirty_bytes > /proc/sys/vm/dirty_bytes
+    [ ${dirty_ratio:-0} -gt 0 ] 2>/dev/null && echo $dirty_ratio > /proc/sys/vm/dirty_ratio
 
     # Use err_file as a semaphore from (...)& process
     if test -e $err_file; then

--- a/initrd/etc/init.d/live-init
+++ b/initrd/etc/init.d/live-init
@@ -153,7 +153,7 @@ do_start() {
     local initrd_release=/etc/initrd_release
     [ -r $initrd_release ] || initrd_release=/etc/initrd-release
     if [ ${#DISTRO} = 0 -a -r $initrd_release ]; then
-        DISTRO=$(sed -n '/^NAME=/{s///; s/["]//g; s/[[:space:]]*$//; p;q}' $initrd_release)
+        DISTRO=$(sed -n "/^NAME=/{s///; s/[\x22']//g; s/[[:space:]]*$//; p;q}" $initrd_release)
     fi
 
     if [ -z "$DISTRO_BASE" ] && [ -n "$DISTRO" ] ; then

--- a/initrd/etc/init.d/live-init
+++ b/initrd/etc/init.d/live-init
@@ -150,9 +150,10 @@ do_start() {
         done
     fi
 
-    if [ ${#DISTRO} = 0 -a -r /etc/initrd-release ]; then
-        DISTRO="$(sed -n 's/^NAME="//' /etc/initrd-release)"
-        DISTRO=${DISTRO%\"}
+    local initrd_release=/etc/initrd_release
+    [ -r $initrd_release ] || initrd_release=/etc/initrd-release
+    if [ ${#DISTRO} = 0 -a -r $initrd_release ]; then
+        DISTRO=$(sed -n '/^NAME=/{s///; s/["]//g; s/[[:space:]]*$//; p;q}' $initrd_release)
     fi
 
     if [ -z "$DISTRO_BASE" ] && [ -n "$DISTRO" ] ; then
@@ -597,7 +598,7 @@ XKBOPTIONS="${XKBOPTIONS:=$default_xkb_opts}"
 
 BACKSPACE="guess"
 Keyboard_Out
-    
+
     # feh: need re-set console keyboard for password prompt
     echo_live "CONSOLE KEYMAP: $(pquote $kb_file)"
     # suppress "ugly" warnings due to an old, known but never fixed German keysym issue
@@ -1189,7 +1190,7 @@ create_home() {
     echo_live "$_Populating_X_directory_" $(pquote $home)
     mkdir -p $home
     cp -a /etc/skel/* /etc/skel/.[!.]* $home 2>/dev/null # Avoid error msgs for ".../* not found"
-    
+
     local uid_gid=$(getent passwd $user | cut -d: -f3,4)
     chown -R $uid_gid $home
 }

--- a/initrd/init
+++ b/initrd/init
@@ -26,8 +26,8 @@
 # that you don't want users to be able to adjust.
 
                      ME="initrd init"
-                VERSION="8.30.14-x13"
-           VERSION_DATE="Mon, 30 Jan 2023 20:35:06 -0500"
+                VERSION="8.30.14-x14"
+           VERSION_DATE="Mon, 27 Feb 2023 07:46:20 -0500"
               DEVELOPER="BitJam"
          BUG_REPORT_URL="liveboot@antixlinux.org"
 
@@ -224,7 +224,10 @@ main_wrapper() {
 
     make_nodes /dev
 
-    read_distro_release /etc/initrd-release
+    local initrd_release=/etc/initrd_release
+    [ -r $initrd_release ] || initrd_release=/etc/initrd-release
+
+    read_distro_release $initrd_release
     : ${DISTRO_BUG_REPORT_URL:=$BUG_REPORT_URL}
     : ${DISTRO_NAME:=antiX}
     : ${DISTRO_BASE:=$DISTRO_NAME}
@@ -4659,8 +4662,8 @@ prog_copy() {
     # Enable cursor
     printf "\e[?25h"
 
-    [ "$dirty_bytes" -ne 0 ] && echo $dirty_bytes >> /proc/sys/vm/dirty_bytes
-    [ "$dirty_ratio" -ne 0 ] && echo $dirty_ratio >> /proc/sys/vm/dirty_ratio
+    [ ${dirty_bytes:-0} -gt 0 ] 2>/dev/null && echo $dirty_bytes > /proc/sys/vm/dirty_bytes
+    [ ${dirty_ratio:-0} -gt 0 ] 2>/dev/null && echo $dirty_ratio > /proc/sys/vm/dirty_ratio
 
     # Use err_file as a semaphore from (...)& process
     if test -e $err_file; then
@@ -4738,8 +4741,8 @@ prog_dd() {
     # Enable cursor
     printf "\e[?25h"
 
-    echo $dirty_bytes >> /proc/sys/vm/dirty_bytes
-    echo $dirty_ratio >> /proc/sys/vm/dirty_ratio
+    [ ${dirty_bytes:-0} -gt 0 ] 2>/dev/null && echo $dirty_bytes > /proc/sys/vm/dirty_bytes
+    [ ${dirty_ratio:-0} -gt 0 ] 2>/dev/null && echo $dirty_ratio > /proc/sys/vm/dirty_ratio
 
     # Use err_file as a semaphore from (...)& process
     if test -e $err_file; then


### PR DESCRIPTION
* use /etc/initrd_release if exists
* fix tsplash bash dirty_bytes/ratio write error
* live-init: trimm double and single quotes from DISTRO_NAME
